### PR TITLE
Refactor: PetRegisterService não é mais uma dependência para instanciar o ViewModel

### DIFF
--- a/petJournal/petJournal/Features/PetRegister/PetRegisterService.swift
+++ b/petJournal/petJournal/Features/PetRegister/PetRegisterService.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 protocol PetRegisterServiceProtocol {
-    func registerPet(petToBeRegistered: PetModel,
+    static func registerPet(petToBeRegistered: PetModel,
                      completion: @escaping(Result<Bool, PetRegisterError>) -> Void)
 }
 
 class PetRegisterService: PetRegisterServiceProtocol {
-    func registerPet(petToBeRegistered: PetModel,
+    static func registerPet(petToBeRegistered: PetModel,
                      completion: @escaping(Result<Bool, PetRegisterError>) -> Void) {
         
         guard let url = URLManager.shared.makeURL(path: URLManager.shared.petRegister) else {

--- a/petJournal/petJournal/Features/PetRegister/PetRegisterService.swift
+++ b/petJournal/petJournal/Features/PetRegister/PetRegisterService.swift
@@ -24,10 +24,10 @@ class PetRegisterService: PetRegisterServiceProtocol {
         var body = Data()
         
         let fields: [String: Any] = [
-            "specieName": petToBeRegistered.specieName,
+            "specieName": petToBeRegistered.specie.detail,
             "petName": petToBeRegistered.petName,
             "gender": petToBeRegistered.gender,
-            "breedName": petToBeRegistered.breedName,
+            "breedName": petToBeRegistered.breed.detail,
             "size": petToBeRegistered.size,
             "castrated": petToBeRegistered.castrated,
             "dateOfBirth": petToBeRegistered.dateOfBirth

--- a/petJournal/petJournal/Features/PetRegister/PetRegisterViewModel.swift
+++ b/petJournal/petJournal/Features/PetRegister/PetRegisterViewModel.swift
@@ -30,9 +30,12 @@ class PetRegisterViewModel: ObservableObject {
 //MARK: - Validation
 extension PetRegisterViewModel {
     var isFieldsFilled: Bool {
-        if !pet.specieName.isEmpty, !pet.petName.isEmpty,
-           !pet.gender.isEmpty, !pet.breedName.isEmpty,
-           !pet.size.isEmpty, !pet.dateOfBirth.isEmpty {
+        if !pet.specie.detail.isEmpty,
+           !pet.petName.isEmpty,
+           !pet.gender.isEmpty,
+           !pet.breed.detail.isEmpty,
+           !pet.size.detail.isEmpty,
+           !pet.dateOfBirth.isEmpty {
             return true
         } else {
             errorMessage = "Por favor, preencha todos os campos."

--- a/petJournal/petJournal/Features/PetRegister/PetRegisterViewModel.swift
+++ b/petJournal/petJournal/Features/PetRegister/PetRegisterViewModel.swift
@@ -7,16 +7,13 @@ class PetRegisterViewModel: ObservableObject {
     @Published var isRequestSuccessful: Bool = false
     @Published var errorMessage: String? = nil
     
-    private var petService: PetRegisterServiceProtocol!
-    init(petService: PetRegisterServiceProtocol) {
-        self.petService = petService
-    }
+    static let shared: PetRegisterViewModel = .init()
     
     func registerPet() {
         isLoading = true
         errorMessage = nil
         
-        petService.registerPet(petToBeRegistered: pet) { [weak self] result in
+        PetRegisterService.registerPet(petToBeRegistered: pet) { [weak self] result in
             DispatchQueue.main.async {
                 self?.isLoading = false
                 switch result {

--- a/petJournal/petJournal/Models/PetModel.swift
+++ b/petJournal/petJournal/Models/PetModel.swift
@@ -2,27 +2,34 @@ import Foundation
 import SwiftUI
 
 struct PetModel: Codable, Identifiable, Hashable {
-    var id = UUID()
-    let specieName: String
-    let petName: String
-    let gender: String
-    let breedName: String
-    let size: String
+    var id: String
+    let guardianID: String?
+    let specie: BreedDetail
+    let specieAlias: String?
+    let petName, gender: String
+    let breedAlias: String?
+    let breed, size: BreedDetail
     let castrated: Bool
     let dateOfBirth: String
     let image: Data?
     var addPet: Bool = false
     
-    init(specieName: String, petName: String,
-         gender: String, breedName: String,
-         size: String, castrated: Bool,
-         dateOfBirth: String, image: Data?,
-         addPet: Bool = false) {
-        self.specieName = specieName
+    init(id: String = UUID().uuidString,
+         guardianID: String, specieName: String,
+         specieAlias: String, petName: String,
+         gender: String, breedAlias: String, 
+         breedName: String, size: String,
+         castrated: Bool, dateOfBirth: String,
+         image: Data?, addPet: Bool) {
+        self.id = id
+        self.guardianID = guardianID
+        self.specie = BreedDetail(detail: specieName)
+        self.specieAlias = specieAlias
         self.petName = petName
         self.gender = gender
-        self.breedName = breedName
-        self.size = size
+        self.breed = BreedDetail(detail: breedName)
+        self.breedAlias = breedAlias
+        self.size = BreedDetail(detail: size)
         self.castrated = castrated
         self.dateOfBirth = dateOfBirth
         self.image = image
@@ -32,30 +39,33 @@ struct PetModel: Codable, Identifiable, Hashable {
 
 extension PetModel {
     static var addPet: PetModel {
-        PetModel(specieName: "", petName: "Adicionar",
-                 gender: "", breedName: "",
-                 size: "", castrated: true,
-                 dateOfBirth: "", image: nil,
-                 addPet: true)
+        PetModel(guardianID: "", specieName: "",
+                 specieAlias: "", petName: "Adicionar",
+                 gender: "", breedAlias: "",
+                 breedName: "", size: "",
+                 castrated: true, dateOfBirth: "",
+                 image: nil, addPet: true)
     }
     //FIXME: Remove mocks
     static var mockPets = [
-        PetModel(specieName: "Cachorro", petName: "Rex", 
-                 gender: "Macho", breedName: "Vira-lata",
-                 size: "Médio", castrated: true,
-                 dateOfBirth: "01/01/2020", image: nil),
-        PetModel(specieName: "Gato", petName: "Mimi",
-                 gender: "Fêmea", breedName: "Siamês",
-                 size: "Pequeno", castrated: false,
-                 dateOfBirth: "15/05/2019", image: nil),
-        PetModel(specieName: "Cachorro", petName: "Luna",
-                 gender: "Fêmea", breedName: "Labrador",
-                 size: "Grande", castrated: true,
-                 dateOfBirth: "10/10/2018", image: nil),
-        PetModel(specieName: "Coelho", petName: "Pernalonga",
-                 gender: "Macho", breedName: "Hotot",
-                 size: "Grande", castrated: true,
-                 dateOfBirth: "01/01/2025", image: nil)
+        PetModel(guardianID: "", specieName: "Cachorro",
+                 specieAlias: "", petName: "Rex",
+                 gender: "Macho", breedAlias: "",
+                 breedName: "Vira-lata", size: "Médio",
+                 castrated: true, dateOfBirth: "01/01/2020",
+                 image: nil, addPet: false),
+        PetModel(guardianID: "", specieName: "Gato",
+                 specieAlias: "", petName: "Mimi",
+                 gender: "Fêmea", breedAlias: "",
+                 breedName: "Siamês", size: "Pequeno",
+                 castrated: false, dateOfBirth: "15/05/2019",
+                 image: nil, addPet: false),
+        PetModel(guardianID: "", specieName: "Cachorro",
+                 specieAlias: "", petName: "Luna",
+                 gender: "Fêmea", breedAlias: "",
+                 breedName: "Labrador", size: "Grande",
+                 castrated: true, dateOfBirth: "10/10/2018",
+                 image: nil, addPet: false)
     ]
     
     static var mockPetImages = [
@@ -74,5 +84,16 @@ extension PetModel {
         } else {
             return PetModel.mockPetImages.randomElement()!
         }
+    }
+}
+
+// MARK: - Breed Detail
+struct BreedDetail: Codable, Identifiable, Hashable {
+    var id: String
+    let detail: String
+
+    init(id: String = UUID().uuidString, detail: String) {
+        self.id = id
+        self.detail = detail
     }
 }


### PR DESCRIPTION
🐾 Refatoração do PetRegisterService e ViewModel  
---  

📌 **Descrição**  
Esta Pull Request refatora o `PetRegisterService` para utilizar funções estáticas, eliminando a necessidade de instanciar o serviço no `ViewModel`. Além disso, a `ViewModel` agora compartilha a mesma instância entre múltiplas telas, garantindo a persistência do estado.  

✨ **Alterações Principais**  
- `PetRegisterService` atualizado para usar funções estáticas.  
- `ViewModel` configurada para ser uma instância compartilhada.  

📊 **Como Testar**  
- Executar o projeto e acessar as telas que utilizam o `PetRegisterService`.  
- Verificar se o serviço funciona corretamente sem precisar ser instanciado no `ViewModel`.  
- Testar a navegação entre telas que compartilham a mesma `ViewModel` e garantir que o estado é mantido.  

✅ **Critérios de Aceite**  
- O `PetRegisterService` opera corretamente sem instâncias criadas no `ViewModel`.  
- O estado da `ViewModel` persiste ao alternar entre telas que a utilizam.  

📣 **Observações**  
- Esta PR faz parte da refatoração para otimizar a escrita de código sem dependências na feature de PetRegister