### PR TITLE
Placeholder e texto do TextField invisíveis no iOS em Dark Mode

### DIFF
--- a/petJournal/petJournal.xcodeproj/project.pbxproj
+++ b/petJournal/petJournal.xcodeproj/project.pbxproj
@@ -34,7 +34,6 @@
 		7542A4782D95C6BF00F712C2 /* PetListService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7542A4772D95C6BF00F712C2 /* PetListService.swift */; };
 		7542A47A2D95DDA500F712C2 /* PetListingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7542A4792D95DDA500F712C2 /* PetListingError.swift */; };
 		754EAA582D85C694000FC465 /* PetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754EAA572D85C694000FC465 /* PetButton.swift */; };
-		759363C32E0B3B6D00B0B69E /* Extension+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759363C22E0B3B6D00B0B69E /* Extension+String.swift */; };
 		75950CB12E04A25A001EC58B /* PetTaskModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75950CB02E04A25A001EC58B /* PetTaskModel.swift */; };
 		75AF95572DAAAB9500CF0A02 /* TaskButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75AF95562DAAAB9500CF0A02 /* TaskButton.swift */; };
 		75C8958F2D84BDA6007BEBA3 /* PetRegisterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C8958E2D84BDA6007BEBA3 /* PetRegisterViewModel.swift */; };
@@ -151,7 +150,6 @@
 		7542A4772D95C6BF00F712C2 /* PetListService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetListService.swift; sourceTree = "<group>"; };
 		7542A4792D95DDA500F712C2 /* PetListingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetListingError.swift; sourceTree = "<group>"; };
 		754EAA572D85C694000FC465 /* PetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetButton.swift; sourceTree = "<group>"; };
-		759363C22E0B3B6D00B0B69E /* Extension+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+String.swift"; sourceTree = "<group>"; };
 		75950CB02E04A25A001EC58B /* PetTaskModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetTaskModel.swift; sourceTree = "<group>"; };
 		75AF95562DAAAB9500CF0A02 /* TaskButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskButton.swift; sourceTree = "<group>"; };
 		75C8958E2D84BDA6007BEBA3 /* PetRegisterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetRegisterViewModel.swift; sourceTree = "<group>"; };
@@ -1048,6 +1046,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = HL9ADSR8LD;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = petJournal/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1078,6 +1077,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = HL9ADSR8LD;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = petJournal/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/petJournal/petJournal/Commons/UIComponents/PJTextFieldView.swift
+++ b/petJournal/petJournal/Commons/UIComponents/PJTextFieldView.swift
@@ -26,59 +26,73 @@ struct PJTextFieldView: PJTextFieldViewProtocol, View {
     var titleFont: Font = .fredokaMedium(size: .small)
     var placeHolderFont: Font = .fredokaMedium(size: .small)
     var validateFieldCallBack: (String) -> Bool
-    
+
     @State var hasToShowErrorMessage: Bool = false
     @State private var isVisiblePassword: Bool = false
     @State private var isEditing: Bool = false
     @Binding var text: String
     @FocusState private var isFocused: Bool
     
+    let emptyPlaceholder = ""
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(title)
                 .foregroundColor(Color.theme.petPrimary500)
                 .font(titleFont)
                 .padding(.bottom, -3)
-            
+
             ZStack {
                 RoundedRectangle(cornerRadius: 10)
-                    .stroke((isFocused || text.count > 0) ? errorValidation ? Color.theme.petGray800 : Color.theme.petPrimary500 : Color.theme.petGray800,lineWidth: 1)
+                    .stroke((isFocused || text.count > 0) ? errorValidation ? Color.theme.petGray800 : Color.theme.petPrimary500 : Color.theme.petGray800, lineWidth: 1)
                     .frame(maxWidth: .infinity, maxHeight: 48)
+                
+                if text.isEmpty {
+                    HStack {
+                        Text(placeholder)
+                            .foregroundColor(Color.theme.petGray300)
+                            .font(placeHolderFont)
+                        Spacer()
+                    }
+                    .padding(.leading, 16)
+                }
+
                 HStack {
                     if textContentType == .password {
                         if !isVisiblePassword {
-                            SecureField(placeholder, text: $text)
+                            SecureField(emptyPlaceholder, text: $text)
                                 .focused($isFocused)
                                 .onChange(of: isFocused, perform: { changed in
-                                        if !changed {
-                                            hasToShowErrorMessage = !validateFieldCallBack(text)
-                                        }
-                                        isFocused = changed
-                                    })
+                                    if !changed {
+                                        hasToShowErrorMessage = !validateFieldCallBack(text)
+                                    }
+                                    isFocused = changed
+                                })
                                 .font(placeHolderFont)
+                                .foregroundStyle(Color.theme.petBlack)
+                                .frame(height: 58)
+                                .disableAutocorrection(true)
+                                .textContentType(.password)
+                                .keyboardType(setKeyboardType())
+                                .autocapitalization(.none)
+                        } else {
+                            TextField(emptyPlaceholder, text: $text)
+                                .focused($isFocused)
+                                .onChange(of: isFocused, perform: { changed in
+                                    if !changed {
+                                        hasToShowErrorMessage = !validateFieldCallBack(text)
+                                    }
+                                    isFocused = changed
+                                })
+                                .font(placeHolderFont)
+                                .foregroundStyle(Color.theme.petBlack)
                                 .frame(height: 58)
                                 .disableAutocorrection(true)
                                 .textContentType(.password)
                                 .keyboardType(setKeyboardType())
                                 .autocapitalization(.none)
                         }
-                        else {
-                            TextField(placeholder, text: $text)
-                                .focused($isFocused)
-                                .onChange(of: isFocused, perform: { changed in
-                                        if !changed {
-                                            hasToShowErrorMessage = !validateFieldCallBack(text)
-                                        }
-                                        isFocused = changed
-                                    })
-                                .font(placeHolderFont)
-                                .frame(height: 58)
-                                .disableAutocorrection(true)
-                                .textContentType(.password)
-                                .keyboardType(setKeyboardType())
-                                .autocapitalization(.none)
-                        }
-                        
+
                         Button {
                             isVisiblePassword.toggle()
                         } label: {
@@ -89,17 +103,17 @@ struct PJTextFieldView: PJTextFieldViewProtocol, View {
                                 .frame(width: 20, height: 20)
                         }
                         .padding(.horizontal, -3)
-                    }
-                    else {
-                        TextField(placeholder, text: $text)
+                    } else {
+                        TextField(emptyPlaceholder, text: $text)
                             .focused($isFocused)
                             .onChange(of: isFocused, perform: { changed in
-                                    if !changed {
-                                        hasToShowErrorMessage = !validateFieldCallBack(text)
-                                    }
-                                    isFocused = changed
-                                })
+                                if !changed {
+                                    hasToShowErrorMessage = !validateFieldCallBack(text)
+                                }
+                                isFocused = changed
+                            })
                             .font(placeHolderFont)
+                            .foregroundStyle(Color.theme.petBlack)
                             .frame(height: 58)
                             .disableAutocorrection(true)
                             .textContentType(textContentType)

--- a/petJournal/petJournal/Commons/UIComponents/PJTextFieldView.swift
+++ b/petJournal/petJournal/Commons/UIComponents/PJTextFieldView.swift
@@ -26,7 +26,7 @@ struct PJTextFieldView: PJTextFieldViewProtocol, View {
     var titleFont: Font = .fredokaMedium(size: .small)
     var placeHolderFont: Font = .fredokaMedium(size: .small)
     var validateFieldCallBack: (String) -> Bool
-
+    
     @State var hasToShowErrorMessage: Bool = false
     @State private var isVisiblePassword: Bool = false
     @State private var isEditing: Bool = false
@@ -34,14 +34,14 @@ struct PJTextFieldView: PJTextFieldViewProtocol, View {
     @FocusState private var isFocused: Bool
     
     let emptyPlaceholder = ""
-
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(title)
                 .foregroundColor(Color.theme.petPrimary500)
                 .font(titleFont)
                 .padding(.bottom, -3)
-
+            
             ZStack {
                 RoundedRectangle(cornerRadius: 10)
                     .stroke((isFocused || text.count > 0) ? errorValidation ? Color.theme.petGray800 : Color.theme.petPrimary500 : Color.theme.petGray800, lineWidth: 1)
@@ -56,7 +56,7 @@ struct PJTextFieldView: PJTextFieldViewProtocol, View {
                     }
                     .padding(.leading, 16)
                 }
-
+                
                 HStack {
                     if textContentType == .password {
                         if !isVisiblePassword {
@@ -92,7 +92,7 @@ struct PJTextFieldView: PJTextFieldViewProtocol, View {
                                 .keyboardType(setKeyboardType())
                                 .autocapitalization(.none)
                         }
-
+                        
                         Button {
                             isVisiblePassword.toggle()
                         } label: {
@@ -144,59 +144,61 @@ extension PJTextFieldView {
         }
     }
 }
+
 struct PJTextFieldView_Previews: PreviewProvider {
+    struct InteractivePreview: View {
+        @State private var emailText = ""
+        @State private var passwordText = ""
+        @State private var phoneText = ""
+        
+        var body: some View {
+            VStack(spacing: 20) {
+                PJTextFieldView(
+                    error: "Endereço de email inválido",
+                    errorValidation: false,
+                    title: "Email",
+                    placeholder: "Digite seu email",
+                    textContentType: .emailAddress,
+                    validateFieldCallBack: { text in
+                        // Simulação de validação
+                        text.contains("@") && text.contains(".")
+                    },
+                    text: $emailText
+                )
+                
+                PJTextFieldView(
+                    error: "A senha precisa ter pelo menos 8 digitos",
+                    errorValidation: passwordText.count < 8,
+                    title: "Senha",
+                    placeholder: "Digite sua senha",
+                    textContentType: .password,
+                    validateFieldCallBack: { text in
+                        text.count >= 8
+                    },
+                    text: $passwordText
+                )
+                
+                PJTextFieldView(
+                    error: "Telefone inválido",
+                    errorValidation: phoneText.count < 11,
+                    title: "Telefone",
+                    placeholder: "Digite seu telefone",
+                    textContentType: .telephoneNumber,
+                    validateFieldCallBack: { number in
+                        number.count >= 11
+                    },
+                    text: $phoneText
+                )
+            }
+            .padding()
+        }
+    }
+    
     static var previews: some View {
         Group {
-            // Light mode
-            VStack {
-                PJTextFieldView(
-                    error: "Endereço de email inválido",
-                    errorValidation: false,
-                    title: "Email",
-                    placeholder: "Digite seu email",
-                    textContentType: .emailAddress,
-                    validateFieldCallBack: { _ in true },
-                    text: .constant("")
-                )
-                
-                PJTextFieldView(
-                    error: "A senha deve ter 8 dígitos",
-                    errorValidation: true,
-                    title: "Senha",
-                    placeholder: "Digite sua senha",
-                    textContentType: .password,
-                    validateFieldCallBack: { _ in false },
-                    text: .constant("")
-                )
-            }
-            .padding()
-            .previewDisplayName("Light Mode")
-            
-            // Dark mode
-            VStack {
-                PJTextFieldView(
-                    error: "Endereço de email inválido",
-                    errorValidation: false,
-                    title: "Email",
-                    placeholder: "Digite seu email",
-                    textContentType: .emailAddress,
-                    validateFieldCallBack: { _ in true },
-                    text: .constant("user@example.com")
-                )
-                
-                PJTextFieldView(
-                    error: "A senha deve ter 8 dígitos",
-                    errorValidation: true,
-                    title: "Senha",
-                    placeholder: "Digite sua senha",
-                    textContentType: .password,
-                    validateFieldCallBack: { _ in false },
-                    text: .constant("short")
-                )
-            }
-            .padding()
-            .preferredColorScheme(.dark)
-            .previewDisplayName("Dark Mode")
+            InteractivePreview()
+                .previewDisplayName("Light Mode")
+                .padding()
         }
     }
 }

--- a/petJournal/petJournal/Commons/UIComponents/PJTextFieldView.swift
+++ b/petJournal/petJournal/Commons/UIComponents/PJTextFieldView.swift
@@ -144,3 +144,59 @@ extension PJTextFieldView {
         }
     }
 }
+struct PJTextFieldView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            // Light mode
+            VStack {
+                PJTextFieldView(
+                    error: "Endereço de email inválido",
+                    errorValidation: false,
+                    title: "Email",
+                    placeholder: "Digite seu email",
+                    textContentType: .emailAddress,
+                    validateFieldCallBack: { _ in true },
+                    text: .constant("")
+                )
+                
+                PJTextFieldView(
+                    error: "A senha deve ter 8 dígitos",
+                    errorValidation: true,
+                    title: "Senha",
+                    placeholder: "Digite sua senha",
+                    textContentType: .password,
+                    validateFieldCallBack: { _ in false },
+                    text: .constant("")
+                )
+            }
+            .padding()
+            .previewDisplayName("Light Mode")
+            
+            // Dark mode
+            VStack {
+                PJTextFieldView(
+                    error: "Endereço de email inválido",
+                    errorValidation: false,
+                    title: "Email",
+                    placeholder: "Digite seu email",
+                    textContentType: .emailAddress,
+                    validateFieldCallBack: { _ in true },
+                    text: .constant("user@example.com")
+                )
+                
+                PJTextFieldView(
+                    error: "A senha deve ter 8 dígitos",
+                    errorValidation: true,
+                    title: "Senha",
+                    placeholder: "Digite sua senha",
+                    textContentType: .password,
+                    validateFieldCallBack: { _ in false },
+                    text: .constant("short")
+                )
+            }
+            .padding()
+            .preferredColorScheme(.dark)
+            .previewDisplayName("Dark Mode")
+        }
+    }
+}


### PR DESCRIPTION
Este PR corrige um problema em que o placeholder e o texto digitado em `TextField` ficavam invisíveis no iOS ao usar o Dark Mode.

A solução implementada envolve:
* `TextField` agora utilizam `emptyPlaceholder` em vez de `placeholder` direto.
* O texto do placeholder é exibido em uma `ZStack`, sobreposto ao `TextField`, com visibilidade condicional baseada na propriedade `text.isEmpty`.