### PR TITLE
Fix: Refatora lógica e nome da função de validação de login

### DIFF
--- a/petJournal/petJournal/Features/AccessAccount/AccessAccountView.swift
+++ b/petJournal/petJournal/Features/AccessAccount/AccessAccountView.swift
@@ -56,8 +56,8 @@ struct AccessAccountView: View {
                         viewModel.authUser()
                     }
                     .frame(width: geometry.size.width * 0.45)
-                    .disabled(viewModel.completeLogin())
-                    .opacity(!viewModel.completeLogin() ? 1 : 0.4)
+                    .disabled(!viewModel.areCredentialsValid())
+                    .opacity(viewModel.areCredentialsValid() ? 1 : 0.4)
                     .alert(isPresented: $viewModel.cancel) {
                         Alert(title: Text("Login"),
                               message: Text("\(viewModel.emailOrPasswordIncorrect)"),

--- a/petJournal/petJournal/Features/AccessAccount/ViewModel/AccessAccountViewModel.swift
+++ b/petJournal/petJournal/Features/AccessAccount/ViewModel/AccessAccountViewModel.swift
@@ -51,12 +51,12 @@ final class AccessAccountViewModel: ObservableObject {
 }
 
 extension AccessAccountViewModel {
-    func completeLogin() -> Bool {
+    func areCredentialsValid() -> Bool {
         if (ValidationsModel.shared.validateInput(user.password, of: .password(.default)) == nil) &&
             (ValidationsModel.shared.validateInput(user.email, of: .email(.default)) == nil) {
-            return false
+            return true
         }
-        return true
+        return false
     }
     
     var isValidEmail: Bool {


### PR DESCRIPTION
Correção de um problema de clareza e lógica na função de validação de credenciais na `AcessAccountViewModel`.

A função anterior, `completeLogin()`, possuía um nome impreciso que não refletia sua real responsabilidade (apenas validar campos). Além disso, sua lógica de retorno booleano era invertida (`false` para sucesso, `true` para falha), o que é contraintuitivo e poderia eventualmente gerar bugs durante a sua utilização

#### **O que foi feito?**

  * ✅ **Renomeação:** A função `completeLogin()` foi renomeada para `areCredentialsValid()`, descrevendo com precisão que ela faz uma verificação.
  * ✅ **Correção da Lógica:** A lógica de retorno foi invertida. Agora a função retorna `true` quando as credenciais são válidas e `false` quando são inválidas.
  * ✅ **Atualização de Chamadas:** Todos os locais que utilizavam o método antigo foram atualizados para refletir o novo nome e a lógica correta.

#### **Como testar?**

1.  Vá para a `AccessAccountView.swift`.
2.  Tente realizar o login com dados **inválidos** (e-mail mal formatado, senha curta, etc.).
3. Dica para senha: "A senha deve ter pelo menos 8 caracteres. Para torna-la mais forte, use letras maiúsculas e minúsculas, números e símbolos como ! @ # $%&*="
4.  Verifique se o comportamento esperado ocorre (o botão de login permanece desabilitado)
5.  Agora, preencha os campos com dados **válidos** (email bem formatado e senha no padrão que se encaixa com a dica que deixei acima).
6.  Verifique se a ação de login pode prosseguir normalmente.